### PR TITLE
chore(galaxy.yml): add more tags

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,17 @@ authors:
 description: Delinea Collection for Ansible.
 license:
   - GPL-3.0-or-later
-tags: [delinea, dsv]
+tags:
+  - delinea
+  - dsv
+  - vault
+  - cloud
+  - application
+  - security
+  - secret
+  - secrets
+  - password
+  - passwords
 
 repository: https://github.com/DelineaXPM/ansible-core-collection
 documentation: https://github.com/DelineaXPM/ansible-core-collection


### PR DESCRIPTION
Turns out it is required to have at least one tag from required tags list:
```python
REQUIRED_TAG_LIST = [
    "application",
    "cloud",
    "database",
    "infrastructure",
    "linux",
    "monitoring",
    "networking",
    "security",
    "storage",
    "tools",
    "windows",
]
```
so this PR adds some from the list and some more extra.