### PR TITLE
fix(mage): install ansible in venv

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -86,7 +86,7 @@ func (Ansible) InstallInVenv() error {
 
 	for _, version := range AnsibleVersions {
 		venvPath := filepath.Join(VenvDirectory, version)
-		pypip := filepath.Join(venvPath, "bin", "pip")
+		pypip := filepath.Join(venvPath, "bin", "pip3")
 
 		pterm.Info.Printfln("installing requirements in venv: %s", venvPath)
 


### PR DESCRIPTION
I've added "pip install wheel" to fix "error: invalid command 'bdist_wheel'" error during installation of Ansible.
Also, to use python from virtual environment you need to run python from the "bin" directory of that venv.

Another issue for me is:
```
ERROR: Package 'ansible-core-2.14.0.dev0' requires a different Python: 3.8.10 not in '>=3.9'
```