### PR TITLE
chore: housekeeping

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.11
       - name: ansible-lint
         uses: reviewdog/action-ansiblelint@v1.6.2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.11

--- a/.github/workflows/test-sanity.yaml
+++ b/.github/workflows/test-sanity.yaml
@@ -29,9 +29,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
           - stable-2.12

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
           - stable-2.12

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -10,7 +10,6 @@ packages:
   - name: direnv/direnv@v2.32.1
   - name: magefile/mage@v1.14.0
   - name: charmbracelet/glow@v1.4.1
-  - name: goreleaser/goreleaser@v1.11.5
   - name: mvdan/gofumpt@v0.4.0
   - name: golang.org/x/tools/gopls@v0.9.5
   - name: golang/tools/gorename@v0.1.12

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -26,16 +26,31 @@ homepage: https://github.com/DelineaXPM/ansible-core-collection
 issues: https://github.com/DelineaXPM/ansible-core-collection/issues
 
 build_ignore:
+  # Directories:
+  - .devcontainer
+  - .github
+  - .trunk
+  - .vscode
+  - .venv
+  - changelogs
+  - venv
+  - vendor
+  # Files:
+  - .changie.yaml
+  - .editorconfig
   - .flake8
   - .gitattributes
   - .github
   - .gitignore
   - .gitleaks.toml
   - .golangci.yml
-  - .markdownlint-cli2.yaml
+  - .markdownlint.yaml
   - .pre-commit-config.yaml
   - .whitesource
   - .yamllint.yaml
+  - aqua.yaml
+  - CHANGELOG.rst
+  - codecov.yml
   - go.mod
   - go.sum
   - magefile.go

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -84,14 +84,14 @@ EXAMPLES = r"""
           msg: 'the password is {{ secret["data"]["password"] }}'
 """
 
-from ansible.errors import AnsibleError, AnsibleOptionsError
-from ansible.plugins.lookup import LookupBase
-from ansible.utils.display import Display
+from ansible.errors import AnsibleError, AnsibleOptionsError  # noqa: E402
+from ansible.plugins.lookup import LookupBase  # noqa: E402
+from ansible.utils.display import Display  # noqa: E402
 
 sdk_is_missing = False
 
 try:
-    from thycotic.secrets.vault import SecretsVault, SecretsVaultError
+    from thycotic.secrets.vault import SecretsVault, SecretsVaultError  # noqa: E402
 except ImportError:
     sdk_is_missing = True
 

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2022, Delinea <https://delinea.com>
+# Copyright: (c) 2023, Delinea <https://delinea.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import absolute_import, division, print_function
 
@@ -85,16 +85,13 @@ EXAMPLES = r"""
 """
 
 from ansible.errors import AnsibleError, AnsibleOptionsError
-from ansible.utils.display import Display
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
 
 sdk_is_missing = False
 
 try:
-    from thycotic.secrets.vault import (
-        SecretsVault,
-        SecretsVaultError,
-    )
+    from thycotic.secrets.vault import SecretsVault, SecretsVaultError
 except ImportError:
     sdk_is_missing = True
 

--- a/tests/unit/plugins/lookup/test_dsv.py
+++ b/tests/unit/plugins/lookup/test_dsv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2022, Delinea <https://delinea.com>
+# (c) 2023, Delinea <https://delinea.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -13,9 +13,9 @@ try:
 except ImportError:
     from mock import patch
 
-from ansible_collections.delinea.core.plugins.lookup import dsv
 from ansible.errors import AnsibleOptionsError
 from ansible.plugins.loader import lookup_loader
+from ansible_collections.delinea.core.plugins.lookup import dsv
 
 
 class TestLookupModule(TestCase):


### PR DESCRIPTION
- bump Python to version 3.11 in gh workflows
- update the year in headers
- remove redundant comments from gh workflows
- lint issues: add `#noqa` for [E402 "Module level import not at top of file"](https://www.flake8rules.com/rules/E402.html)
- galaxy.yml: add more files to ignore during build