### PR TITLE
docs: 📘 add dsv plugin documentation link at top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Ansible core collection for Delinea DevOps Secrets Vault.
 
 ### Lookup plugins
 
-| Name             | Description                                        |
-| ---------------- | -------------------------------------------------- |
-| delinea.core.dsv | Look up secrets from Delinea DevOps Secrets Vault. |
+> **Note**
+> Review the plugin documentation linked below for example usage.
+
+| Name                                                                                                      | Description                                        |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [delinea.core.dsv](https://docs.ansible.com/ansible/latest/collections/community/general/dsv_lookup.html) | Look up secrets from Delinea DevOps Secrets Vault. |
 
 ## Using this collection
 


### PR DESCRIPTION
Improve the discoverability of the plugin docs rendered by Ansible. By default this required googling and Ansible galaxy doesn't immediately link the information in their browsing experience.

- fixes #45